### PR TITLE
Chaining between AsyncArray methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,18 +226,27 @@ console.log(output);
 // Output is true
 ```
 
-## Chaining methods
+## Chaining
 
-### Please note that `.aEvery`, `.aFilter`, `.aFind`, `.aForEach`, `.aMap`, `aReduce` and  `.aSome` cannot be chained with each other.
+## Between AsyncRay methods
 
-Eg:
+### **Only** `.aFilter`, `.aForEach` amd `.aMap` may be chained together.
 
+Make sure to put before each AsyncRay method call an `await` (or call `.then(...)`) since a Promise is returned by the async methods.
+
+#### sample 1 - `aMap` and `aFilter`
 ```js
-// Below code will throw an error
-AsyncRay([1,2,3]).aMap(...).aReduce(...)
+await(
+  await AsyncRay([1,2,3])
+    .aMap(...))
+    .aFilter(...)
+)
 ```
 
-But `.aEvery`, `.aFilter`, `.aFind`,`.aFindIndex`, `.aForEach`, `.aMap`, `aReduce`, `aReduceRight` and  `.aSome` can be chained with other [Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#).
+
+## Between other [Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#) methods
+
+`.aEvery`, `.aFilter`, `.aFind`,`.aFindIndex`, `.aForEach`, `.aMap`, `aReduce`, `aReduceRight` and  `.aSome` can be chained with other [Array methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#).
 
 #### sample 1 - `aMap` and `filter`
 

--- a/README.md
+++ b/README.md
@@ -230,17 +230,15 @@ console.log(output);
 
 ## Between AsyncRay methods
 
-### **Only** `.aFilter`, `.aForEach` amd `.aMap` may be chained together.
+### **Only** `.aFilter` and `.aMap` may be chained together.
 
 Make sure to put before each AsyncRay method call an `await` (or call `.then(...)`) since a Promise is returned by the async methods.
 
-#### sample 1 - `aMap` and `aFilter`
+#### sample
 ```js
-await(
-  await AsyncRay([1,2,3])
-    .aMap(...))
-    .aFilter(...)
-)
+await(await AsyncRay([1,2,3])
+    .aFilter(...))
+    .Map(...)
 ```
 
 

--- a/lib/async_ray.ts
+++ b/lib/async_ray.ts
@@ -71,10 +71,8 @@ export class AsyncArray<T> extends Array<T> {
    * @returns {Promise<void>}
    * @memberof AsyncArray
    */
-  async aForEach(cb: Methods.CallBackForEach<T>): Promise<AsyncArray<T>> {
+  async aForEach(cb: Methods.CallBackForEach<T>): Promise<void> {
     await Methods.forEach<T>(this.input, cb);
-    
-    return this;
   }
 
   /**

--- a/lib/async_ray.ts
+++ b/lib/async_ray.ts
@@ -39,7 +39,6 @@ export class AsyncArray<T> extends Array<T> {
    * @memberof AsyncArray
    */
   async aFilter(cb: Methods.CallBackFilter<T>): Promise<AsyncArray<T>> {
-    // console.log(...await Methods.filter<T>(this.input, cb));
     return new AsyncArray(...await Methods.filter<T>(this.input, cb));
   }
 

--- a/lib/async_ray.ts
+++ b/lib/async_ray.ts
@@ -38,8 +38,9 @@ export class AsyncArray<T> extends Array<T> {
    * @returns {Promise<T[]>}
    * @memberof AsyncArray
    */
-  async aFilter(cb: Methods.CallBackFilter<T>): Promise<T[]> {
-    return Methods.filter<T>(this.input, cb);
+  async aFilter(cb: Methods.CallBackFilter<T>): Promise<AsyncArray<T>> {
+    // console.log(...await Methods.filter<T>(this.input, cb));
+    return new AsyncArray(...await Methods.filter<T>(this.input, cb));
   }
 
   /**
@@ -71,8 +72,10 @@ export class AsyncArray<T> extends Array<T> {
    * @returns {Promise<void>}
    * @memberof AsyncArray
    */
-  async aForEach(cb: Methods.CallBackForEach<T>): Promise<void> {
+  async aForEach(cb: Methods.CallBackForEach<T>): Promise<AsyncArray<T>> {
     await Methods.forEach<T>(this.input, cb);
+    
+    return this;
   }
 
   /**
@@ -83,8 +86,8 @@ export class AsyncArray<T> extends Array<T> {
    * @returns {Promise<R[]>}
    * @memberof AsyncArray
    */
-  async aMap<R>(cb: Methods.CallBackMap<T, R>): Promise<R[]> {
-    return Methods.map<T, R>(this.input, cb);
+  async aMap<R>(cb: Methods.CallBackMap<T, R>): Promise<AsyncArray<R>> {
+    return new AsyncArray(...await Methods.map<T, R>(this.input, cb));
   }
 
   /**

--- a/test/chaining.ts
+++ b/test/chaining.ts
@@ -1,9 +1,14 @@
 import 'mocha';
 import * as should from 'should';
 import { AsyncRay } from '../lib/';
+import { AsyncArray } from '../lib/async_ray';
 
 async function dummyAsync(num: number): Promise<number> {
   return Promise.resolve(num * 10);
+}
+
+async function dummyAsyncCond(condition: boolean): Promise<boolean> {
+  return Promise.resolve(condition);
 }
 
 function dummy(num: number): number {
@@ -16,7 +21,22 @@ describe('Chaining', () => {
     inputArray = [1, 2, 3, 4];
   });
 
-  it('Chaining aMap() and map()', async () => {
+  it('aMap(), aFilter() and aForEach()', async () => {
+    const outputArray = 
+      await( 
+        await( 
+          await AsyncRay(inputArray)
+            .aMap(async (i) => 
+              dummyAsync(i)))
+        .aFilter(async (i) => 
+          dummyAsyncCond(!!i)))
+      .aForEach(async (i) => 
+        undefined)
+
+    should(outputArray).instanceOf(AsyncArray);
+  });
+
+  it('aMap() and map()', async () => {
     const outputArray = (await AsyncRay(inputArray).aMap(async (i) =>
       dummyAsync(i)
     )).map(dummy);
@@ -24,7 +44,7 @@ describe('Chaining', () => {
     should(outputArray).containDeepOrdered([100, 200, 300, 400]);
   });
 
-  it('Chaining aMap() and reduce()', async () => {
+  it('aMap() and reduce()', async () => {
     const output = (await AsyncRay(inputArray).aMap(async (i) =>
       dummyAsync(i)
     )).reduce((acc, i) => acc + dummy(i), 100);
@@ -32,7 +52,7 @@ describe('Chaining', () => {
     should(output).eql(1100);
   });
 
-  it('Chaining aMap() and find()', async () => {
+  it('aMap() and find()', async () => {
     const output = (await AsyncRay(inputArray).aMap(async (i) =>
       dummyAsync(i)
     )).find((e) => e === 20);
@@ -40,7 +60,7 @@ describe('Chaining', () => {
     should(output).eql(20);
   });
 
-  it('Chaining aFilter() and map()', async () => {
+  it('aFilter() and map()', async () => {
     const outputArray = (await AsyncRay(inputArray).aFilter(
       async (i) => (await dummyAsync(i)) > 20
     )).map(dummy);
@@ -48,7 +68,7 @@ describe('Chaining', () => {
     should(outputArray).containDeepOrdered([30, 40]);
   });
 
-  it('Chaining aFilter() and reduce()', async () => {
+  it('aFilter() and reduce()', async () => {
     const output = (await AsyncRay(inputArray).aFilter(
       async (i) => (await dummyAsync(i)) > 20
     )).reduce((acc, i) => acc + dummy(i), 100);
@@ -56,7 +76,7 @@ describe('Chaining', () => {
     should(output).eql(170);
   });
 
-  it('Chaining aFilter() and find()', async () => {
+  it('aFilter() and find()', async () => {
     const output = (await AsyncRay(inputArray).aFilter(
       async (i) => (await dummyAsync(i)) > 20
     )).find((e) => e === 4);

--- a/test/chaining.ts
+++ b/test/chaining.ts
@@ -25,9 +25,9 @@ describe('Chaining', () => {
     const outputArray = 
       await(await AsyncRay(inputArray)
         .aMap(async (i) => 
-          dummyAsync(i))
+          dummyAsync(i)))
         .aFilter(async (i) => 
-          dummyAsyncCond(!!i)
+          dummyAsyncCond(!!i))
 
     should(outputArray).instanceOf(AsyncArray);
   });

--- a/test/chaining.ts
+++ b/test/chaining.ts
@@ -21,17 +21,13 @@ describe('Chaining', () => {
     inputArray = [1, 2, 3, 4];
   });
 
-  it('aMap(), aFilter() and aForEach()', async () => {
+  it('aMap() and aFilter()', async () => {
     const outputArray = 
-      await( 
-        await( 
-          await AsyncRay(inputArray)
-            .aMap(async (i) => 
-              dummyAsync(i)))
+      await(await AsyncRay(inputArray)
+        .aMap(async (i) => 
+          dummyAsync(i))
         .aFilter(async (i) => 
-          dummyAsyncCond(!!i)))
-      .aForEach(async (i) => 
-        undefined)
+          dummyAsyncCond(!!i)
 
     should(outputArray).instanceOf(AsyncArray);
   });

--- a/test/filter.ts
+++ b/test/filter.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 import * as should from 'should';
 import { AsyncRay } from '../lib/';
+import { AsyncArray } from '../lib/async_ray';
 
 async function dummy(condition: boolean): Promise<boolean> {
   return Promise.resolve(condition);
@@ -13,6 +14,14 @@ describe('AsyncRay', () => {
   });
 
   describe('filter', () => {
+    it('should return an instance of AsyncArray', async () => {
+      const outputArray = await AsyncRay(inputArray).aFilter(
+        async (i) => dummy(!!i)
+      );
+      
+      should(outputArray).instanceOf(AsyncArray);
+    });
+
     it('should filter and send a none-empty array', async () => {
       const outputArray = await AsyncRay(inputArray).aFilter(
         async (i, index, collection) => {
@@ -50,7 +59,7 @@ describe('AsyncRay', () => {
 
       should(outputArray)
         .instanceOf(Array)
-        .empty();
+        .length(0);
     });
   });
 });

--- a/test/foreach.ts
+++ b/test/foreach.ts
@@ -1,7 +1,6 @@
 import 'mocha';
 import * as should from 'should';
 import { AsyncRay } from '../lib/';
-import { AsyncArray } from '../lib/async_ray';
 
 async function dummy(num: number): Promise<number> {
   return Promise.resolve(num);
@@ -14,14 +13,6 @@ describe('AsyncRay', () => {
   });
 
   describe('forEach', () => {
-    it('should return an instance of AsyncArray', async () => {
-      const outputArray = await AsyncRay(inputArray).aForEach(
-        async () => undefined
-      );
-      
-      should(outputArray).instanceOf(AsyncArray);
-    });
-
     it('should execute the loop', async () => {
       const outputArray: number[] = [];
       await AsyncRay(inputArray).aForEach(async (i, index, collection) => {

--- a/test/foreach.ts
+++ b/test/foreach.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 import * as should from 'should';
 import { AsyncRay } from '../lib/';
+import { AsyncArray } from '../lib/async_ray';
 
 async function dummy(num: number): Promise<number> {
   return Promise.resolve(num);
@@ -13,6 +14,14 @@ describe('AsyncRay', () => {
   });
 
   describe('forEach', () => {
+    it('should return an instance of AsyncArray', async () => {
+      const outputArray = await AsyncRay(inputArray).aForEach(
+        async () => undefined
+      );
+      
+      should(outputArray).instanceOf(AsyncArray);
+    });
+
     it('should execute the loop', async () => {
       const outputArray: number[] = [];
       await AsyncRay(inputArray).aForEach(async (i, index, collection) => {

--- a/test/map.ts
+++ b/test/map.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 import * as should from 'should';
 import { AsyncRay } from '../lib/';
+import { AsyncArray } from '../lib/async_ray';
 
 async function dummy(num: number): Promise<number> {
   return Promise.resolve(num * 10);
@@ -13,6 +14,14 @@ describe('AsyncRay', () => {
   });
 
   describe('map', () => {
+    it('should return an instance of AsyncArray', async () => {
+      const outputArray = await AsyncRay(inputArray).aMap(
+        async () => null
+      );
+      
+      should(outputArray).instanceOf(AsyncArray);
+    });
+
     it('should map the given cb', async () => {
       const outputArray = await AsyncRay(inputArray).aMap(
         async (i, index, collection) => {


### PR DESCRIPTION
# Synopsis
- Support for chaining between AsyncArray methods that return an Array - i.e `aMap` & `aFilter`
- ~~Also changed the return type of `aForEach` to return `this`, which add chaining functionality to this method as well.~~